### PR TITLE
Add support for API options

### DIFF
--- a/maps.js
+++ b/maps.js
@@ -229,10 +229,16 @@ var request = require('request'),
         });
     },
 
+    /**
+     * Merge options objects
+     * @param {Object} options The custom options to be merged with defaults
+     * @param {Function} defaults Default options
+     * @private
+     */
     mergeOptions = function(options, defaults) {
       var results = {};
       for (var attrname in defaults) { results[attrname] = defaults[attrname]; }
-      for (var attrname in options) { defaults[attrname] = options[attrname]; }
+      for (var attrname in options) { results[attrname] = options[attrname]; }
       return results;
     };
 

--- a/maps.js
+++ b/maps.js
@@ -52,6 +52,17 @@ var request = require('request'),
     BING_MAPS_API_KEY = process.env.BING_MAPS_API_KEY,
 
     /**
+     * Default options, stored here so they can be set by the developer
+     * @type {Object}
+     * @private
+     */
+    DEFAULT_OPTIONS = {
+        'optimize': 'time', // The Bing API can also accept 'distance' or 'timeWithTraffic'
+        'distanceUnit': 'mi', // The Bing API can also accept 'km'
+        'outputType': 'json' // The Bing API can also accept 'xml'
+    };
+
+    /**
      * Treat the specified `obj` object as a flat collection of key-value pairs
      * and convert it to a query string prefixed with ? and ready to be concatenated
      * with a URL.
@@ -117,12 +128,15 @@ var request = require('request'),
      */
     getDefaultOptions = function() {
         curTime = new Date();
-        return {
-            'optimize': 'time', // The Bing API can also accept 'distance' or 'timeWithTraffic'
-            'distanceUnit': 'mi', // The Bing API can also accept 'km'
-            'outputType': 'json' // The Bing API can also accept 'xml'
-        };
+        return DEFAULT_OPTIONS;
     },
+
+    /**
+     * Set the default hash of options for Bing Maps web service calls.
+     */
+    setDefaultOptions = function(options) {
+      DEFAULT_OPTIONS = options;
+    }
 
     /**
      * Create a default options hash specific to transit directions web service requests.

--- a/maps.js
+++ b/maps.js
@@ -228,16 +228,11 @@ var request = require('request'),
             }
         });
     };
-
-    mergeOptions = function(options, defaults) {
-      var results = options.concat(defaults);
-      for(var i=0; i<results.length; ++i) {
-          for(var j=i+1; j<results.length; ++j) {
-              if(results[i] === results[j])
-                results.splice(j--, 1);
-          }
-      }
-
+    
+    mergeOptions = function(options, defaults){
+      var results = {};
+        for (var attrname in defaults) { results[attrname] = defaults[attrname]; }
+        for (var attrname in options) { results[attrname] = options[attrname]; }
       return results;
     };
 

--- a/maps.js
+++ b/maps.js
@@ -271,9 +271,9 @@ var request = require('request'),
  *
  * @since 0.0.1
  */
-exports.getTransitRoute = function(startLocation, endLocation, options, callback) {
-    var options = mergeOptions(options, getDefaultTransitOptions()),
-        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
+exports.getTransitRoute = function(startLocation, endLocation, callback, options) {
+    var merged_options = mergeOptions(options || {}, getDefaultTransitOptions()),
+        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, merged_options),
         requestUrl = createTransitUrl(queryStringArgs);
     callBingApi(requestUrl, callback);
 }
@@ -307,9 +307,9 @@ exports.getTransitRoute = function(startLocation, endLocation, options, callback
  *
  * @since 0.0.3
  */
-exports.getWalkingRoute = function(startLocation, endLocation, options, callback) {
-    var options = mergeOptions(options, getDefaultWalkingOptions()),
-        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
+exports.getWalkingRoute = function(startLocation, endLocation, callback, options) {
+    var merged_options = mergeOptions(options || {}, getDefaultWalkingOptions()),
+        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, merged_options),
         requestUrl = createWalkingUrl(queryStringArgs);
     callBingApi(requestUrl, callback);
 }
@@ -343,9 +343,9 @@ exports.getWalkingRoute = function(startLocation, endLocation, options, callback
  *
  * @since 0.0.6
  */
-exports.getDrivingRoute = function(startLocation, endLocation, options, callback) {
-    var options = mergeOptions(options, getDefaultDrivingOptions()),
-        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
+exports.getDrivingRoute = function(startLocation, endLocation, callback, options) {
+    var merged_options = mergeOptions(options || {}, getDefaultDrivingOptions()),
+        queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, merged_options),
         requestUrl = createDrivingUrl(queryStringArgs);
     callBingApi(requestUrl, callback);
 }

--- a/maps.js
+++ b/maps.js
@@ -229,7 +229,7 @@ var request = require('request'),
         });
     },
 
-    mergeOptions = function(options, defaults){
+    mergeOptions = function(options, defaults) {
       var results = {};
       for (var attrname in defaults) { results[attrname] = defaults[attrname]; }
       for (var attrname in options) { defaults[attrname] = options[attrname]; }

--- a/maps.js
+++ b/maps.js
@@ -52,17 +52,6 @@ var request = require('request'),
     BING_MAPS_API_KEY = process.env.BING_MAPS_API_KEY,
 
     /**
-     * Default options, stored here so they can be set by the developer
-     * @type {Object}
-     * @private
-     */
-    DEFAULT_OPTIONS = {
-        'optimize': 'time', // The Bing API can also accept 'distance' or 'timeWithTraffic'
-        'distanceUnit': 'mi', // The Bing API can also accept 'km'
-        'outputType': 'json' // The Bing API can also accept 'xml'
-    };
-
-    /**
      * Treat the specified `obj` object as a flat collection of key-value pairs
      * and convert it to a query string prefixed with ? and ready to be concatenated
      * with a URL.
@@ -128,15 +117,12 @@ var request = require('request'),
      */
     getDefaultOptions = function() {
         curTime = new Date();
-        return DEFAULT_OPTIONS;
+        return {
+            'optimize': 'time', // The Bing API can also accept 'distance' or 'timeWithTraffic'
+            'distanceUnit': 'mi', // The Bing API can also accept 'km'
+            'outputType': 'json' // The Bing API can also accept 'xml'
+        };
     },
-
-    /**
-     * Set the default hash of options for Bing Maps web service calls.
-     */
-    setDefaultOptions = function(options) {
-      DEFAULT_OPTIONS = options;
-    }
 
     /**
      * Create a default options hash specific to transit directions web service requests.
@@ -243,6 +229,18 @@ var request = require('request'),
         });
     };
 
+    mergeOptions = function(options, defaults) {
+      var results = options.concat(defaults);
+      for(var i=0; i<results.length; ++i) {
+          for(var j=i+1; j<results.length; ++j) {
+              if(results[i] === results[j])
+                results.splice(j--, 1);
+          }
+      }
+
+      return results;
+    };
+
 /**
  * Make a request to the Bing maps API to get transit directions between
  * two addresses.
@@ -273,7 +271,7 @@ var request = require('request'),
  * @since 0.0.1
  */
 exports.getTransitRoute = function(startLocation, endLocation, callback) {
-    var options = getDefaultTransitOptions(),
+    var options = mergeOptions(options, getDefaultTransitOptions()),
         queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
         requestUrl = createTransitUrl(queryStringArgs);
     callBingApi(requestUrl, callback);
@@ -308,8 +306,8 @@ exports.getTransitRoute = function(startLocation, endLocation, callback) {
  *
  * @since 0.0.3
  */
-exports.getWalkingRoute = function(startLocation, endLocation, callback) {
-    var options = getDefaultWalkingOptions(),
+exports.getWalkingRoute = function(startLocation, endLocation, options, callback) {
+    var options = mergeOptions(options, getDefaultWalkingOptions()),
         queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
         requestUrl = createWalkingUrl(queryStringArgs);
     callBingApi(requestUrl, callback);
@@ -344,8 +342,8 @@ exports.getWalkingRoute = function(startLocation, endLocation, callback) {
  *
  * @since 0.0.6
  */
-exports.getDrivingRoute = function(startLocation, endLocation, callback) {
-    var options = getDefaultDrivingOptions(),
+exports.getDrivingRoute = function(startLocation, endLocation, options, callback) {
+    var options = mergeOptions(options, getDefaultDrivingOptions()),
         queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
         requestUrl = createDrivingUrl(queryStringArgs);
     callBingApi(requestUrl, callback);

--- a/maps.js
+++ b/maps.js
@@ -227,12 +227,12 @@ var request = require('request'),
                 }
             }
         });
-    };
-    
+    },
+
     mergeOptions = function(options, defaults){
       var results = {};
-        for (var attrname in defaults) { results[attrname] = defaults[attrname]; }
-        for (var attrname in options) { results[attrname] = options[attrname]; }
+      for (var attrname in defaults) { results[attrname] = defaults[attrname]; }
+      for (var attrname in options) { defaults[attrname] = options[attrname]; }
       return results;
     };
 

--- a/maps.js
+++ b/maps.js
@@ -271,7 +271,7 @@ var request = require('request'),
  *
  * @since 0.0.1
  */
-exports.getTransitRoute = function(startLocation, endLocation, callback) {
+exports.getTransitRoute = function(startLocation, endLocation, options, callback) {
     var options = mergeOptions(options, getDefaultTransitOptions()),
         queryStringArgs = convertLocationsAndOptionsToQueryStringArgs(startLocation, endLocation, options),
         requestUrl = createTransitUrl(queryStringArgs);

--- a/maps.js
+++ b/maps.js
@@ -250,6 +250,7 @@ var request = require('request'),
  * @param {String} endLocation The destination address for the directions.
  * @param {Function} callback The function to call when a response is received
  * from the Bing API or an error occurs.
+ * @param {Object} options Options for the API call (override defaults)
  *
  * If the request to the Bing API returns an error, or a non 200 response code
  * the the specified callback will be invoked with the an error object as the
@@ -286,6 +287,7 @@ exports.getTransitRoute = function(startLocation, endLocation, callback, options
  * @param {String} endLocation The destination address for the directions.
  * @param {Function} callback The function to call when a response is received
  * from the Bing API or an error occurs.
+ * @param {Object} options Options for the API call (override defaults)
  *
  * If the request to the Bing API returns an error, or a non 200 response code
  * the the specified callback will be invoked with the an error object as the
@@ -322,6 +324,7 @@ exports.getWalkingRoute = function(startLocation, endLocation, callback, options
  * @param {String} endLocation The destination address for the directions.
  * @param {Function} callback The function to call when a response is received
  * from the Bing API or an error occurs.
+ * @param {Object} options Options for the API call (override defaults)
  *
  * If the request to the Bing API returns an error, or a non 200 response code
  * the the specified callback will be invoked with the an error object as the


### PR DESCRIPTION
Comments in the code indicate that other options are available through the Bing API but there's no way to use them without modifying the source. I've added support for an options object that will be merged with the defaults.
